### PR TITLE
Fix Fn::GetAtt string handling

### DIFF
--- a/__tests__/reference.js
+++ b/__tests__/reference.js
@@ -37,5 +37,5 @@ test('name uses GetAtt string', t => {
     value: { 'Fn::GetAtt': 'foo.Attr' }
   });
 
-	t.deepEqual(reference.getDependencyName(), 'fooAttr');
+  t.deepEqual(reference.getDependencyName(), 'fooAttr');
 });

--- a/__tests__/reference.js
+++ b/__tests__/reference.js
@@ -31,3 +31,11 @@ test('name uses GetAtt', t => {
 
 	t.deepEqual(reference.getDependencyName(), 'fooAttr');
 });
+
+test('name uses GetAtt string', t => {
+  const reference = new Reference('foo', {
+    value: { 'Fn::GetAtt': 'foo.Attr' }
+  });
+
+	t.deepEqual(reference.getDependencyName(), 'fooAttr');
+});

--- a/__tests__/utils/get-referenced-resources.js
+++ b/__tests__/utils/get-referenced-resources.js
@@ -98,12 +98,17 @@ test('should find GetAtt references', t => {
             'Fn::GetAtt': ['def', 'arn']
           }
         },
+        NestedString: {
+          Two: {
+            'Fn::GetAtt': 'defstr.arn'
+          }
+        },
         Three: 'zzz'
       }
     });
 
   t.deepEqual(references.length, 2);
-  t.deepEqual(_.difference(references.map(r => r.id), ['abc', 'def']).length, 0);
+  t.deepEqual(_.difference(references.map(r => r.id), ['abc', 'def', 'defstr']).length, 0);
 });
 
 test('should find Join references', t => {

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -8,7 +8,9 @@ module.exports = class Reference {
 
   getDependencyName() {
     if ('Fn::GetAtt' in this.value) {
-      return this.value['Fn::GetAtt'].join('');
+      let getAtt = this.value['Fn::GetAtt'];
+      if (typeof getAtt === 'string') getAtt = getAtt.split('.');
+      return getAtt.join('');
     }
     return this.id;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -187,8 +187,8 @@ module.exports = {
 
         if (Ref && Ref in this.resourcesById) {
           references.push(new Reference(Ref, current));
-        } else if (Array.isArray(GetAtt)) {
-          const id = GetAtt[0];
+        } else if (GetAtt) {
+          const id = typeof GetAtt === 'string' ? GetAtt.split('.', 1)[0] : GetAtt[0];
 
           if (id in this.resourcesById) {
             references.push(new Reference(id, current));


### PR DESCRIPTION
[Fn::GetAtt](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html) supports also short string notation (where values are delimited with `.`).

This patch ensures that _string_ representation is also discovered properly