### PR TITLE
Configure 'test-bare' script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,30 @@
 version: 2
 jobs:
-  build:
+  lint:
     docker:
-      # specify the version you desire here
+      - image: circleci/node:6.11
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run: npm run lint
+
+  test:
+    docker:
       - image: circleci/node:6.11
 
     working_directory: ~/repo
@@ -25,3 +47,10 @@ jobs:
 
       # run tests!
       - run: npm test
+
+workflows:
+  version: 2
+  test_and_lint:
+    jobs:
+      - lint
+      - test

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Split Serverless deployments in to nested CloudFormation stacks",
   "main": "split-stacks.js",
   "scripts": {
-    "test-bare": "ava",
-    "test": "nyc --all ava",
-    "integration-test": "node __tests__/_integration.js",
-    "posttest": "eslint ."
+    "coverage": "nyc --all npm test",
+    "lint": "eslint .",
+    "test": "ava",
+    "integration-test": "node __tests__/_integration.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Split Serverless deployments in to nested CloudFormation stacks",
   "main": "split-stacks.js",
   "scripts": {
+    "test-bare": "ava",
     "test": "nyc --all ava",
     "integration-test": "node __tests__/_integration.js",
     "posttest": "eslint ."


### PR DESCRIPTION
The problem with `test` script is that it involves coverage wrap and eventual error reports do not map to code locations as in files.

In projects I maintain I usually keep following convention:
- `test` - bare tests
- `coverage` - coverage report (obviously comes with test run, and fails if tests fail, so equivalent to `test` as it's now)
- `check-coverage` - Runs `coverage` and fails if coverage is below predefined threshold

Then in CI config, I configure one run to use `check-coverage` and others to run `test` (e.g. when testing multiple Node.js version). If you like it I can also update it to reflect that.