### PR TITLE
Fix parametrization of "resource migrated" case

### DIFF
--- a/lib/replace-references.js
+++ b/lib/replace-references.js
@@ -15,7 +15,8 @@ module.exports = function replaceReferences() {
     _.each(references, dependency => {
       this.reconcile(resourceId, dependency.id, {
         ResourceMigrated: (resourceMigration) => {
-          const parameter = resourceMigration.parameterize(dependency.id, dependency.value);
+          const parameter =
+            resourceMigration.parameterize(dependency.getDependencyName(), dependency.value);
 
           dependency.replace(parameter);
 


### PR DESCRIPTION
When working out on _stack per lambda_ configuration. I approached a CloudFormation error stating `Invalid Resource identifier specified` on `AWS::ApiGateway::Resource` type.

It happened for case in which I wanted to keep `ApiGatewayRestApi` in main stack (instead of moving it to `Api` stack), and moving lambda related `AWS::ApiGateway::Resource` resource into lambda stack (the `ResourceMigrated` case)

What's important all was fine, when `ApiGatewayRestApi` was moved into `Api` stack, and lambda dedicated API resourced were propagated to lambda dedicated stack (the `ResourceAndDependencyMigrated` case).

Problem was that what was parametrized in `ResourceMigrated` case was not full dependency name (`ApiGatewayRestApiRootResourceId` in that case) but just dependency id (`ApiGatewayRestApi`).
In turn following:

```json
"ParentId": {
  "Fn::GetAtt": [
    "ApiGatewayRestApi",
    "RootResourceId"
  ]
}
```

Was replaced, with something that has effect of:

```json
"ParentId": {
  "Fn::GetAtt": [
    "ApiGatewayRestApi"
  ]
}
```

That in turn lead to `Invalid Resource identifier specified`  error. This patch fixes that.

---

I wanted to add some test for it, but found that those cases are not really tested, and it's not straightforward to add it with current tests setup.

At this point my resources are limited, but would you be open at some point to reconfigure tests so they all work purely against main [`split`](https://github.com/dougmoscrop/serverless-plugin-split-stacks/blob/88c8ef95bf68ddcc282508c21aa9de0b34af1474/split-stacks.js#L43-L57) function?

I find currently implemented approach quite problematic, as even small re-factoring of internals that doesn't influence the outcome, may break tests and make it hard to fix (I stumbled on some issues already at #10).
