### PR TITLE
Fix provider.request invocation

### DIFF
--- a/split-stacks.js
+++ b/split-stacks.js
@@ -86,10 +86,7 @@ class ServerlessPluginSplitStacks {
             ContentType: 'application/json',
           };
 
-          return this.provider.request('S3', 'putObject',
-            params,
-            this.options.stage,
-            this.options.region);
+          return this.provider.request('S3', 'putObject', params);
         }));
       });
   }


### PR DESCRIPTION
Signature of this method changed on SLS side, also those two parameters were never supported
https://github.com/serverless/serverless/pull/4537

Currently running plugin with recent version of SLS produces numerous warnings as:

[`Serverless: WARNING: Inappropriate call of provider.request()`](https://github.com/serverless/serverless/blob/1c0758e24386102e4163d0e435386ea6cde3b7e3/lib/plugins/aws/provider/awsProvider.js#L222)
