### PR TITLE
Now, remove non alphanumeric characters from dependency name

### DIFF
--- a/__tests__/reference.js
+++ b/__tests__/reference.js
@@ -48,3 +48,11 @@ test('name uses GetAtt string', t => {
 
   t.deepEqual(reference.getDependencyName(), 'fooAttr');
 });
+
+test('should remove non alphanumeric characters', t => {
+  const reference = new Reference('foo', {
+    value: { 'Fn::GetAtt': ['Database', 'Endpoint.Port'] }
+  });
+
+  t.deepEqual(reference.getDependencyName(), 'DatabaseEndpointPort');
+})

--- a/__tests__/reference.js
+++ b/__tests__/reference.js
@@ -51,8 +51,16 @@ test('name uses GetAtt string', t => {
 
 test('should remove non alphanumeric characters', t => {
   const reference = new Reference('foo', {
-    value: { 'Fn::GetAtt': ['Database', 'Endpoint.Port'] }
+    value: { 'Fn::GetAtt': ['Database', 'Endpoint>Port'] }
   });
 
   t.deepEqual(reference.getDependencyName(), 'DatabaseEndpointPort');
+})
+
+test('should replace from . to Dot', t => {
+  const reference = new Reference('foo', {
+    value: { 'Fn::GetAtt': ['Database', 'Endpoint.Port'] }
+  });
+
+  t.deepEqual(reference.getDependencyName(), 'DatabaseEndpointDotPort');
 })

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -10,7 +10,7 @@ module.exports = class Reference {
     if (typeof this.value === 'object' && this.value && 'Fn::GetAtt' in this.value) {
       let getAtt = this.value['Fn::GetAtt'];
       if (typeof getAtt === 'string') getAtt = getAtt.split('.');
-      return getAtt.join('');
+      return getAtt.join('').replace(/[^a-zA-Z0-9]*/gi, '');
     }
     return this.id;
   }

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -10,7 +10,9 @@ module.exports = class Reference {
     if (typeof this.value === 'object' && this.value && 'Fn::GetAtt' in this.value) {
       let getAtt = this.value['Fn::GetAtt'];
       if (typeof getAtt === 'string') getAtt = getAtt.split('.');
-      return getAtt.join('').replace(/[^a-zA-Z0-9]*/gi, '');
+      return getAtt.join('')
+        .replace(/\./g, 'Dot')
+        .replace(/[^a-zA-Z0-9]*/gi, '');
     }
     return this.id;
   }


### PR DESCRIPTION
When you split stacks per function and your environment has a variable pointing to a resource with nested parameter, the dependency name will broke because cloud formation parameters don't allow non alphanumeric characters, causing a serverless error: "An error occurred: IndexNestedStack - Template format error: Parameter name MemoryDatabaseRedisEndpoint.PortParameter is non alphanumeric."

I resolved this problem, removing non alphanumeric characters from the dependency name.

Here is a sample
```yml
service: sample-error

provider:
  name: aws
  stage: ${opt:stage, 'qa'}
  runtime: nodejs8.10
  environment:
    REDIS_HOST:
      Fn::GetAtt: [MemoryDatabase, RedisEndpoint.Address]
    REDIS_PORT:
      Fn::GetAtt: [MemoryDatabase, RedisEndpoint.Port]

custom:
  splitStacks:
    perFunction: true
    perType: false

functions:
  index:
    handler: index.handler
    events:
      - http:
          path: '/'
          method: get
          cors: true

resources:
  Resources:
    MemoryDatabase:
      Type: AWS::ElastiCache::CacheCluster
      Properties:
        ClusterName: ${self:service}-${self:provider.stage}
        CacheNodeType: cache.t2.micro
        NumCacheNodes: 1
        Engine: redis
        EngineVersion: 3.2.10
        CacheSecurityGroupNames:
          - default

plugins:
  - serverless-plugin-split-stacks

```