### PR TITLE
fix support ignore special resource by stacks-map.js

### DIFF
--- a/__tests__/migration-strategy/custom.js
+++ b/__tests__/migration-strategy/custom.js
@@ -189,3 +189,23 @@ test('static map and exported function', t => {
   t.deepEqual(strategy.migration({ Type: 'Foo::Bar' }, 'Foo'), { destination: 'Foo' });
   t.deepEqual(strategy.migration({ Type: 'Bar' }, 'asdf'), { destination: 'Bar' });
 });
+
+test('ignoring just a few resource', t => {
+  const serverless = {
+    version: '1.13.0',
+    config: {
+      servicePath: `${__dirname}/fixtures/working-fn`
+    },
+    service: {
+      custom: {}
+    },
+    getProvider: () => {}
+  };
+
+  Plugin.resolveMigration = sinon.stub().returns(false);
+
+  const plugin = new Plugin(serverless);
+  const strategy = new Custom(plugin);
+
+  t.deepEqual(strategy.migration({ Type: 'Foo::Bar' }, 'Foo'), false);
+});

--- a/lib/migration-strategy/custom.js
+++ b/lib/migration-strategy/custom.js
@@ -47,6 +47,10 @@ module.exports = class Custom {
       if (migration) {
         return migration;
       }
+
+      if (migration === false) {
+        return false;
+      }
     }
 
     if (typeof this.customStackMapping === 'function') {


### PR DESCRIPTION
Support ignore special resource by stacks-map.js
Deploy using the nested stacks by function but ignoring just a few functions.

```
module.exports = (resource, logicalId) => {
  if (logicalId === 'MyFunctionThatShouldNotBeMigrated') {
    return false
  }
  // undefined means move on to other strategy, such as perType
};
```
In curent version, the function does not working correctly.
https://github.com/dougmoscrop/serverless-plugin-split-stacks/blob/d2f20edbaed73fa57069739440e929c22dc7c099/lib/migrate-new-resources.js#L23