### PR TITLE
fix(utils): use region specific template url for China

### DIFF
--- a/__tests__/split-stacks.js
+++ b/__tests__/split-stacks.js
@@ -11,6 +11,7 @@ test.beforeEach(t => {
     version: '1.13.2',
     service: {
       provider: {
+        region: 'us-east-1',
         compiledCloudFormationTemplate: sampleTemplate
       },
       package: {}

--- a/__tests__/utils/bucket-endpoint.js
+++ b/__tests__/utils/bucket-endpoint.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const test = require('ava');
+const sinon = require('sinon');
+const https = require('https');
+
+const originalRequest = https.request;
+
+test.beforeEach(t => {
+  https.request = originalRequest;
+  t.context = Object.assign(
+    {},
+    { serverless: { service: { provider: {} } } }
+  );
+});
+
+test('sets correct deployment bucket for bucket in a region', t => {
+  const setDeploymentBucketEndpoint = require('../../lib/deployment-bucket-endpoint');
+
+  t.context.serverless.service.provider.deploymentBucket = 'danyel-test';
+  t.context.options = { region: 'us-east-1' };
+  const request = {};
+  request.on = sinon.fake.returns(undefined);
+  request.end = sinon.fake.returns(undefined);
+  https.request = sinon.fake.returns(request);
+  const promise = setDeploymentBucketEndpoint.apply(t.context, []);
+
+  // assert called
+  t.true(https.request.calledOnce);
+  t.true(request.on.calledWith('response'));
+  t.true(request.on.calledWith('error'));
+  t.true(request.end.calledOnce);
+
+  // invoke fake response
+  const responseCall = request.on.getCalls().find(e => e.args[0] === 'response');
+  const callback = responseCall.args[1];
+  callback({ headers: { 'x-amz-bucket-region': 'eu-west-1' } });
+  return promise.then(() => {
+      t.deepEqual(t.context.deploymentBucketEndpoint, 's3.eu-west-1.amazonaws.com');
+    });
+});

--- a/__tests__/utils/nested-stack-resource.js
+++ b/__tests__/utils/nested-stack-resource.js
@@ -7,6 +7,7 @@ const utils = require('../../lib/utils');
 
 test.beforeEach(t => {
 	t.context = Object.assign({}, utils, {
+		deploymentBucketEndpoint: 's3.amazonaws.com',
 		serverless: {
 			service: {
 				provider: {},

--- a/lib/deployment-bucket-endpoint.js
+++ b/lib/deployment-bucket-endpoint.js
@@ -1,0 +1,44 @@
+'use-strict';
+
+const { endpoint } = require('aws-info');
+const https = require('https');
+
+const dnsCompatible = (name) => name.match(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/) !== null;
+
+const emitDnsDeprecationWarning = (cli, bucket) => {
+  cli.log(`WARNING: DNS incompatible bucket name detected (${bucket}).`);
+  cli.log(`    These will cause errors starting 30 Sep 2020 due to S3 API changes`);
+  cli.log(`    and SSL certificate mismatches for virtual-hosting style S3 URLs.`);
+  cli.log(`    Read more here: https://forums.aws.amazon.com/ann.jspa?annID=6776`);
+}
+
+module.exports = function setDeploymentBucketEndpoint() {
+  const bucket = this.serverless.service.provider.deploymentBucket;
+  const ourRegion = this.options.region || this.serverless.service.provider.region
+  const s3Endpoint = endpoint('S3', ourRegion);
+  if (bucket === undefined) {
+    this.deploymentBucketEndpoint = s3Endpoint;
+  } else {
+    return new Promise((resolve, reject) => {
+      const options = {
+        method: 'HEAD',
+      };
+      if (dnsCompatible(bucket)) {
+        options.hostname = `${bucket}.${s3Endpoint}`;
+        options.path = '/';
+      } else {
+        emitDnsDeprecationWarning(this.serverless.cli, bucket);
+        options.hostname = s3Endpoint;
+        options.path = `/${bucket}`;
+      }
+      const request = https.request(options);
+      request.on('response', response => {
+        const bucketRegion = response.headers['x-amz-bucket-region'];
+        this.deploymentBucketEndpoint = endpoint('S3', bucketRegion);
+        resolve();
+      });
+      request.on('error', reject);
+      request.end();
+    });
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,7 +87,7 @@ module.exports = {
          TemplateURL: {
            'Fn::Join': [
              '/', [
-               'https://s3.amazonaws.com',
+               `https://${this.deploymentBucketEndpoint}`,
                this.serverless.service.provider.deploymentBucket || { Ref: 'ServerlessDeploymentBucket' },
                this.serverless.service.package.artifactDirectoryName,
                fileName

--- a/package-lock.json
+++ b/package-lock.json
@@ -989,6 +989,11 @@
         }
       }
     },
+    "aws-info": {
+      "version": "1.0.0",
+      "resolved": "https://syskronx.jfrog.io/syskronx/api/npm/npm/aws-info/-/aws-info-1.0.0.tgz",
+      "integrity": "sha1-JyfSQXBoFpof53ZYEG5U4V4wdjs="
+    },
     "aws-sdk": {
       "version": "2.428.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.428.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "sinon": "^7.3.0"
   },
   "dependencies": {
+    "aws-info": "^1.0.0",
     "lodash": "^4.17.5",
     "semver": "^5.6.0",
     "throat": "^4.1.0"

--- a/split-stacks.js
+++ b/split-stacks.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const semver = require('semver');
 
+const setDeploymentBucketEndpoint = require('./lib/deployment-bucket-endpoint');
 const migrateExistingResources = require('./lib/migrate-existing-resources');
 const migrateNewResources = require('./lib/migrate-new-resources');
 const replaceReferences = require('./lib/replace-references');
@@ -31,6 +32,7 @@ class ServerlessPluginSplitStacks {
 
     Object.assign(this,
       utils,
+      { setDeploymentBucketEndpoint },
       { migrateExistingResources },
       { migrateNewResources },
       { replaceReferences },
@@ -54,6 +56,7 @@ class ServerlessPluginSplitStacks {
     this.resourceMigrations = {};
 
     return Promise.resolve()
+      .then(() => this.setDeploymentBucketEndpoint())
       .then(() => this.migrateExistingResources())
       .then(() => this.migrateNewResources())
       .then(() => this.replaceReferences())


### PR DESCRIPTION
In Western regions the S3 object URL starts with `https://s3.amazonaws.com`, independent of the region. For Chinese regions, the suffix obviously is `amazonaws.com.cn`, but there is a second quirk: the region is also encoded in the URL: `https://s3.${region}.amazonaws.com.cn`. This S3 object URL is needed when creating stacks or nested stacks, so our usage of the `serverless-plugin-split-stacks` is not possible for an automated deployment to China unless this PR is merged.

As for the region: it seems that only those two values are relevant for the region that serverless deploys to, the environment variables `AWS_DEFAULT_REGION` and `AWS_REGION` are ignored. But I can't 100% vouch for it -- so far, this has been causing no problems for us.

The other (potentially breaking) approach would be to add a condition to the stack root, something like this:

```js
const template = this.serverless.service.provider.compiledCloudFormationTemplate;
template.Conditions = template.Conditions || {};
// the following might potentially break
// if the end user already has this condition declared
// and it does something completely different
template.Conditions.China = { 'Fn::Equals': [ { Ref: 'AWS::URLSuffix' }, 'amazonaws.com.cn' ] };
const s3domain = { 'Fn::If': [
  'China',
  { 'Fn::Sub': 's3.${AWS::Region}.amazonaws.com.cn' },
  's3.amazonaws.com'
] }
```