### PR TITLE
[Features] Add a new migration strategy and control over nested stack deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ custom:
   splitStacks:
     perFunction: false
     perType: true
+    perGroupFunction: false
 ```
 
 ## Migration Strategies
@@ -22,6 +23,37 @@ This splits resources off in to a nested stack dedicated to the associated Lambd
 ### Per Type
 
 This moves resources in to a nested stack for the given resource type. If `Per Lambda` is enabled, it takes precedence over `Per Type`.
+
+### Per Lambda Group
+
+This splits resources off in to a nested stack dedicated to a set of Lambda functions and associated resources. The resources within the nested stack are declared as depending on each others to avoid the `API rate limit` error due to fast deployments. If `Per Lambda` or `Per Type` is enabled, it takes precedence over `Per Lambda Group`. In order to control the number of nested stacks, more configurations are needed:
+
+```yaml
+custom:
+  splitStacks:
+    nestedStackCount: 20 # Controls the number of created nested stacks
+    perFunction: false
+    perType: false
+    perGroupFunction: true
+    resourceParallelDeployments: 10 # Controls how much resources are deployed in parallel
+```
+
+Once set, the `nestedStackCount` configuration should never be changed because the only reliable method of changing it later on is to recreate the deployment from scratch.
+
+## Stack Sequences
+
+In order to avoid `API rate limit` errors, it is possible to configure nested stacks to depend on each others. This feature comes with a new set of configuration:
+
+
+```yaml
+custom:
+  splitStacks:
+    perFunction: true
+    perType: false
+    perGroupFunction: false
+    stackSequence: true
+    stackParallelDeployments: 5 # Controls how much stacks are deployed in parallel
+```
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This moves resources in to a nested stack for the given resource type. If `Per L
 
 ### Per Lambda Group
 
-This splits resources off in to a nested stack dedicated to a set of Lambda functions and associated resources. The resources within the nested stack are declared as depending on each others to avoid the `API rate limit` error due to fast deployments. If `Per Lambda` or `Per Type` is enabled, it takes precedence over `Per Lambda Group`. In order to control the number of nested stacks, more configurations are needed:
+This splits resources off in to a nested stack dedicated to a set of Lambda functions and associated resources. If `Per Lambda` or `Per Type` is enabled, it takes precedence over `Per Lambda Group`. In order to control the number of nested stacks, following configurations are needed:
 
 ```yaml
 custom:
@@ -35,14 +35,17 @@ custom:
     perFunction: false
     perType: false
     perGroupFunction: true
-    resourceParallelDeployments: 10 # Controls how much resources are deployed in parallel
 ```
 
 Once set, the `nestedStackCount` configuration should never be changed because the only reliable method of changing it later on is to recreate the deployment from scratch.
 
-## Stack Sequences
+## Concurrency
 
-In order to avoid `API rate limit` errors, it is possible to configure nested stacks to depend on each others. This feature comes with a new set of configuration:
+In order to avoid `API rate limit` errors, it is possible to configure the plugin in 2 different ways:
+ * Set nested stacks to depend on each others.
+ * Set resources in the nested stack to depend on each others.
+
+This feature comes with a 2 new configurations, `stackConcurrency` and `resourceConcurrency` :
 
 
 ```yaml
@@ -51,8 +54,8 @@ custom:
     perFunction: true
     perType: false
     perGroupFunction: false
-    stackSequence: true
-    stackParallelDeployments: 5 # Controls how much stacks are deployed in parallel
+    stackConcurrency: 5 # Controls if enabled and how much stacks are deployed in parallel. Disabled if absent.
+    resourceConcurrency: 10 # Controls how much resources are deployed in parallel. Disabled if absent.
 ```
 
 ## Limitations

--- a/__tests__/migration-strategy/fixtures/per-function/api-gateway-resources.js
+++ b/__tests__/migration-strategy/fixtures/per-function/api-gateway-resources.js
@@ -1,0 +1,46 @@
+module.exports = [
+  {
+    functionName: "exampleOne",
+    http: {
+      path: "example/one",
+      method: "get",
+      cors: {
+        origins: ["*"],
+        origin: "*",
+        methods: ["OPTIONS", "GET"],
+        headers: [
+          "Content-Type",
+          "X-Amz-Date",
+          "Authorization",
+          "X-Api-Key",
+          "X-Amz-Security-Token",
+          "X-Amz-User-Agent"
+        ],
+        allowCredentials: false
+      },
+      integration: "AWS_PROXY"
+    }
+  },
+  {
+    functionName: "exampleTwo",
+    http: {
+      path: "example/two",
+      method: "get",
+      cors: {
+        origins: ["*"],
+        origin: "*",
+        methods: ["OPTIONS", "GET"],
+        headers: [
+          "Content-Type",
+          "X-Amz-Date",
+          "Authorization",
+          "X-Api-Key",
+          "X-Amz-Security-Token",
+          "X-Amz-User-Agent"
+        ],
+        allowCredentials: false
+      },
+      integration: "AWS_PROXY"
+    }
+  }
+];

--- a/__tests__/migration-strategy/fixtures/per-function/migration-resources.js
+++ b/__tests__/migration-strategy/fixtures/per-function/migration-resources.js
@@ -1,0 +1,61 @@
+module.exports = {
+  // Example One
+  'exampleOneLambdaPermissionApiGateway': {
+    Type: 'AWS::Lambda::Permission',
+    Destination: 'exampleOne'
+  },
+  'exampleOneLambdaFunction': {
+    Type: 'AWS::Lambda::Function',
+    Destination: 'exampleOne'
+  },
+  'exampleOneLogGroup': {
+    Type: 'AWS::Logs::LogGroup',
+    Destination: 'exampleOne'
+  },
+  'example/one': {
+    Type: 'AWS::ApiGateway::Resource',
+    Destination: 'exampleOne'
+  },
+  'example/oneget': {
+    Type: 'AWS::ApiGateway::Method',
+    Destination: 'exampleOne'
+  },
+  'example/oneOPTIONS': {
+    Type: 'AWS::ApiGateway::Method',
+    Destination: 'exampleOne'
+  },
+
+  // Example Two
+  'exampleTwoLambdaPermissionApiGateway': {
+    Type: 'AWS::Lambda::Permission',
+    Destination: 'exampleTwo'
+  },
+  'exampleTwoLambdaFunction': {
+    Type: 'AWS::Lambda::Function',
+    Destination: 'exampleTwo'
+  },
+  'exampleTwoLogGroup': {
+    Type: 'AWS::Logs::LogGroup',
+    Destination: 'exampleTwo'
+  },
+  'example/two': {
+    Type: 'AWS::ApiGateway::Resource',
+    Destination: 'exampleTwo'
+  },
+  'example/twoget': {
+    Type: 'AWS::ApiGateway::Method',
+    Destination: 'exampleTwo'
+  },
+  'example/twoOPTIONS': {
+    Type: 'AWS::ApiGateway::Method',
+    Destination: 'exampleTwo'
+  },
+
+  // Other
+  'NotMigrated': {
+    Type: 'AWS::ApiGateway::Method'
+  },
+  'YetAnotherOneNotMigrated': {
+    Type: 'AWS::Lambda::Permission'
+  }
+};

--- a/__tests__/migration-strategy/fixtures/per-group-function/api-gateway-resources.js
+++ b/__tests__/migration-strategy/fixtures/per-group-function/api-gateway-resources.js
@@ -1,0 +1,68 @@
+module.exports = [
+  {
+    functionName: "exampleOne",
+    http: {
+      path: "example/one",
+      method: "get",
+      cors: {
+        origins: ["*"],
+        origin: "*",
+        methods: ["OPTIONS", "GET"],
+        headers: [
+          "Content-Type",
+          "X-Amz-Date",
+          "Authorization",
+          "X-Api-Key",
+          "X-Amz-Security-Token",
+          "X-Amz-User-Agent"
+        ],
+        allowCredentials: false
+      },
+      integration: "AWS_PROXY"
+    }
+  },
+  {
+    functionName: "exampleTwo",
+    http: {
+      path: "example/two",
+      method: "get",
+      cors: {
+        origins: ["*"],
+        origin: "*",
+        methods: ["OPTIONS", "GET"],
+        headers: [
+          "Content-Type",
+          "X-Amz-Date",
+          "Authorization",
+          "X-Api-Key",
+          "X-Amz-Security-Token",
+          "X-Amz-User-Agent"
+        ],
+        allowCredentials: false
+      },
+      integration: "AWS_PROXY"
+    }
+  },
+  {
+    functionName: "exampleThree",
+    http: {
+      path: "example/three",
+      method: "get",
+      cors: {
+        origins: ["*"],
+        origin: "*",
+        methods: ["OPTIONS", "GET"],
+        headers: [
+          "Content-Type",
+          "X-Amz-Date",
+          "Authorization",
+          "X-Api-Key",
+          "X-Amz-Security-Token",
+          "X-Amz-User-Agent"
+        ],
+        allowCredentials: false
+      },
+      integration: "AWS_PROXY"
+    }
+  }
+];

--- a/__tests__/migration-strategy/fixtures/per-group-function/migration-resources.js
+++ b/__tests__/migration-strategy/fixtures/per-group-function/migration-resources.js
@@ -1,0 +1,92 @@
+module.exports = {
+  // Example One
+  'exampleOneLambdaPermissionApiGateway': {
+    Type: 'AWS::Lambda::Permission',
+    Migrated: true
+  },
+  'exampleOneLambdaFunction': {
+    Type: 'AWS::Lambda::Function',
+    DependsOn: ['exampleOneLogGroup'],
+    Migrated: true
+  },
+  'exampleOneLogGroup': {
+    Type: 'AWS::Logs::LogGroup',
+    Migrated: true
+  },
+  'example/one': {
+    Type: 'AWS::ApiGateway::Resource',
+    Migrated: true
+  },
+  'example/oneget': {
+    Type: 'AWS::ApiGateway::Method',
+    Migrated: true
+  },
+  'example/oneOPTIONS': {
+    Type: 'AWS::ApiGateway::Method',
+    Migrated: true
+  },
+
+  // Example Two
+  'exampleTwoLambdaPermissionApiGateway': {
+    Type: 'AWS::Lambda::Permission',
+    Migrated: true
+  },
+  'exampleTwoLambdaFunction': {
+    Type: 'AWS::Lambda::Function',
+    DependsOn: ['exampleTwoLogGroup'],
+    Migrated: true
+  },
+  'exampleTwoLogGroup': {
+    Type: 'AWS::Logs::LogGroup',
+    Migrated: true
+  },
+  'example/two': {
+    Type: 'AWS::ApiGateway::Resource',
+    Migrated: true
+  },
+  'example/twoget': {
+    Type: 'AWS::ApiGateway::Method',
+    Migrated: true
+  },
+  'example/twoOPTIONS': {
+    Type: 'AWS::ApiGateway::Method',
+    Migrated: true
+  },
+
+  // Example Two
+  'exampleThreeLambdaPermissionApiGateway': {
+    Type: 'AWS::Lambda::Permission',
+    Migrated: true
+  },
+  'exampleThreeLambdaFunction': {
+    Type: 'AWS::Lambda::Function',
+    DependsOn: ['exampleThreeLogGroup'],
+    Migrated: true
+  },
+  'exampleThreeLogGroup': {
+    Type: 'AWS::Logs::LogGroup',
+    Migrated: true
+  },
+  'example/three': {
+    Type: 'AWS::ApiGateway::Resource',
+    Migrated: true
+  },
+  'example/threeget': {
+    Type: 'AWS::ApiGateway::Method',
+    Migrated: true
+  },
+  'example/threeOPTIONS': {
+    Type: 'AWS::ApiGateway::Method',
+    Migrated: true
+  },
+
+  // Other
+  'NotMigrated': {
+    Type: 'AWS::ApiGateway::Method',
+    Migrated: false
+  },
+  'YetAnotherOneNotMigrated': {
+    Type: 'AWS::Lambda::Permission',
+    Migrated: false
+  }
+};

--- a/__tests__/migration-strategy/per-function.js
+++ b/__tests__/migration-strategy/per-function.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const sinon = require('sinon');
+const test = require('ava');
+
+const PerFunction = require('../../lib/migration-strategy/per-function');
+
+const clone = function (object) {
+  return JSON.parse(JSON.stringify(object));
+};
+
+test.beforeEach(t => {
+  const apiGatewayPlugin = {
+    constructor: {
+      name: 'AwsCompileApigEvents'
+    },
+    validated: {
+      events: require('./fixtures/per-function/api-gateway-resources')
+    },
+    getResourceName: sinon.stub().returnsArg(0)
+  };
+
+  const plugin = {
+    config: {},
+    serverless: {
+      config: {
+        servicePath: __dirname
+      },
+      pluginManager: {
+        plugins: [apiGatewayPlugin]
+      },
+      service: {
+        functions: {
+          'exampleOne': {},
+          'exampleTwo': {}
+        }
+      }
+    },
+    provider: {
+      naming: {
+        getNormalizedFunctionName: sinon.stub().returnsArg(0),
+        getMethodLogicalId: sinon.stub().callsFake((name, method) => name + method),
+        getResourceLogicalId: sinon.stub().returnsArg(0)
+      }
+    },
+    getStackName: () => 'test'
+  };
+  t.context = Object.assign({}, { plugin });
+});
+
+test('can be disabled', t => {
+  t.context.plugin.config.perFunction = false;
+
+  const migrationStrategy = new PerFunction(t.context.plugin);
+
+  t.falsy(migrationStrategy.lambdaNames);
+});
+
+test('initializes if enabled', t => {
+  t.context.plugin.config.perFunction = true;
+
+  const migrationStrategy = new PerFunction(t.context.plugin);
+
+  t.truthy(migrationStrategy.lambdaNames);
+  t.is(migrationStrategy.apiGatewayResourceMap.size, 6);
+});
+
+test('does not migrate resources if disabled', t => {
+  t.context.plugin.config.perFunction = false;
+  t.plan(14);
+
+  const migrationStrategy = new PerFunction(t.context.plugin);
+  const migrationResources = clone(require('./fixtures/per-function/migration-resources'));
+
+  Object.keys(migrationResources).forEach(logicalId => {
+    const migration = migrationStrategy.migration(migrationResources[logicalId], logicalId);
+
+    t.falsy(migration);
+  });
+});
+
+test('migrates resources depending on lambda name', t => {
+  t.context.plugin.config.perFunction = true;
+  t.plan(26);
+
+  const migrationStrategy = new PerFunction(t.context.plugin);
+  const migrationResources = clone(require('./fixtures/per-function/migration-resources'));
+
+  Object.keys(migrationResources).forEach(logicalId => {
+    const migration = migrationStrategy.migration(migrationResources[logicalId], logicalId);
+
+    if (migrationResources[logicalId].Destination) {
+      t.truthy(migration && migration.destination);
+      t.is(migration.destination, migrationResources[logicalId].Destination);
+    } else {
+      t.falsy(migration);
+    }
+  });
+});
+

--- a/__tests__/migration-strategy/per-group-function.js
+++ b/__tests__/migration-strategy/per-group-function.js
@@ -128,10 +128,10 @@ test('migrates resources in Nested Stacks', t => {
   });
 });
 
-test('migrates resources in Nested Stacks and ', t => {
+test('migrates resources in Nested Stacks and with resource concurrency', t => {
   t.context.plugin.config.perGroupFunction = true;
   t.context.plugin.config.nestedStackCount = 2;
-  t.context.plugin.config.resourceParallelDeployments = 2;
+  t.context.plugin.config.resourceConcurrency = 2;
   t.plan(22);
 
   const migrationStrategy = new PerGroupFunction(t.context.plugin);

--- a/__tests__/migration-strategy/per-group-function.js
+++ b/__tests__/migration-strategy/per-group-function.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const sinon = require('sinon');
+const test = require('ava');
+
+const PerGroupFunction = require('../../lib/migration-strategy/per-group-function');
+
+const clone = function (object) {
+  return JSON.parse(JSON.stringify(object));
+};
+
+const countDependsOn = function (resources) {
+  return Object.keys(resources).filter(resourceName => resources[resourceName].DependsOn).length
+};
+
+const doesNotBecomeCircular = function (resources) {
+  const memo = {};
+
+  Object.keys(resources).forEach(resourceName => {
+    const resource = resources[resourceName];
+    if (resource.DependsOn) {
+      resource.DependsOn.forEach(parent => {
+        if (!memo[parent]) {
+          memo[parent] = [resourceName];
+        } else {
+          memo[parent].push(resourceName);
+        }
+      });
+    }
+  });
+
+  return Object.keys(memo).every(parentName => memo[parentName].length <= 1);
+};
+
+test.beforeEach(t => {
+  const apiGatewayPlugin = {
+    constructor: {
+      name: 'AwsCompileApigEvents'
+    },
+    validated: {
+      events: require('./fixtures/per-group-function/api-gateway-resources')
+    },
+    getResourceName: sinon.stub().returnsArg(0)
+  };
+
+  const plugin = {
+    config: {},
+    serverless: {
+      config: {
+        servicePath: __dirname
+      },
+      pluginManager: {
+        plugins: [apiGatewayPlugin]
+      },
+      service: {
+        functions: {
+          'exampleOne': {},
+          'exampleTwo': {},
+          'exampleThree': {}
+        }
+      }
+    },
+    provider: {
+      naming: {
+        getNormalizedFunctionName: sinon.stub().returnsArg(0),
+        getMethodLogicalId: sinon.stub().callsFake((name, method) => name + method),
+        getResourceLogicalId: sinon.stub().returnsArg(0)
+      }
+    },
+    getStackName: () => 'test'
+  };
+  t.context = Object.assign({}, { plugin });
+});
+
+test('can be disabled', t => {
+  t.context.plugin.config.perGroupFunction = false;
+
+  const migrationStrategy = new PerGroupFunction(t.context.plugin);
+
+  t.falsy(migrationStrategy.lambdaNames);
+});
+
+test('throws an error if configured badly', t => {
+  t.context.plugin.config.perGroupFunction = true;
+  t.context.plugin.config.nestedStackCount = 1;
+
+  t.throws(() => {
+    new PerGroupFunction(t.context.plugin);
+  });
+});
+
+test('initializes if enabled', t => {
+  t.context.plugin.config.perGroupFunction = true;
+  t.context.plugin.config.nestedStackCount = 2;
+
+  const migrationStrategy = new PerGroupFunction(t.context.plugin);
+
+  t.truthy(migrationStrategy.lambdaNames);
+  t.is(migrationStrategy.apiGatewayResourceMap.size, 9);
+});
+
+test('does not migrate resources if disabled', t => {
+  t.context.plugin.config.perGroupFunction = false;
+  t.plan(20);
+
+  const migrationStrategy = new PerGroupFunction(t.context.plugin);
+  const migrationResources = clone(require('./fixtures/per-group-function/migration-resources'));
+
+  Object.keys(migrationResources).forEach(logicalId => {
+    const migration = migrationStrategy.migration(migrationResources[logicalId], logicalId);
+
+    t.falsy(migration);
+  });
+});
+
+test('migrates resources in Nested Stacks', t => {
+  t.context.plugin.config.perGroupFunction = true;
+  t.context.plugin.config.nestedStackCount = 2;
+  t.plan(20);
+
+  const migrationStrategy = new PerGroupFunction(t.context.plugin);
+  const migrationResources = clone(require('./fixtures/per-group-function/migration-resources'));
+
+  Object.keys(migrationResources).forEach(logicalId => {
+    const migration = migrationStrategy.migration(migrationResources[logicalId], logicalId);
+
+    t.is(Boolean(migration), migrationResources[logicalId].Migrated);
+  });
+});
+
+test('migrates resources in Nested Stacks and ', t => {
+  t.context.plugin.config.perGroupFunction = true;
+  t.context.plugin.config.nestedStackCount = 2;
+  t.context.plugin.config.resourceParallelDeployments = 2;
+  t.plan(22);
+
+  const migrationStrategy = new PerGroupFunction(t.context.plugin);
+  const migrationResources = clone(require('./fixtures/per-group-function/migration-resources'));
+
+  Object.keys(migrationResources).forEach(logicalId => {
+    const migration = migrationStrategy.migration(migrationResources[logicalId], logicalId);
+
+    t.is(Boolean(migration), migrationResources[logicalId].Migrated);
+  });
+
+  t.is(countDependsOn(migrationResources), 13);
+  t.true(doesNotBecomeCircular(migrationResources));
+});

--- a/__tests__/sequence-stacks.js
+++ b/__tests__/sequence-stacks.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const test = require('ava');
+
+const sequenceStacks = require('../lib/sequence-stacks');
+
+const countDependsOn = function (resources) {
+  return Object.keys(resources).filter(resourceName => resources[resourceName].DependsOn).length
+};
+
+const doesNotBecomeCircular = function (resources) {
+  const memo = {};
+
+  Object.keys(resources).forEach(resourceName => {
+    const resource = resources[resourceName];
+    if (resource.DependsOn) {
+      resource.DependsOn.forEach(parent => {
+        if (!memo[parent]) {
+          memo[parent] = [resourceName];
+        } else {
+          memo[parent].push(resourceName);
+        }
+      });
+    }
+  });
+
+  return Object.keys(memo).every(parentName => memo[parentName].length <= 1);
+};
+
+test.beforeEach(t => {
+  t.context = Object.assign({ sequenceStacks }, {
+    config: {},
+    serverless: {
+      config: {
+        servicePath: __dirname
+      }
+    },
+    provider: {},
+    getStackName: () => 'test',
+    nestedStacks: {
+      '1NestedStack': {},
+      '2NestedStack': {},
+      '3NestedStack': {},
+      '4NestedStack': {},
+      '5NestedStack': {},
+      '6NestedStack': {},
+      '7NestedStack': {},
+      '8NestedStack': {},
+      '9NestedStack': {},
+      '10NestedStack': {}
+    },
+    rootTemplate: {
+      Resources: {
+        '1NestedStack': {},
+        '2NestedStack': {},
+        '3NestedStack': {},
+        '4NestedStack': {},
+        '5NestedStack': {},
+        '6NestedStack': {},
+        '7NestedStack': {},
+        '8NestedStack': {},
+        '9NestedStack': {},
+        '10NestedStack': {}
+      }
+    }
+  });
+});
+
+test('does nothing if parallelDeployments is disabled', t => {
+  t.context.config.stackSequence = false;
+
+  t.context.sequenceStacks();
+
+  t.is(0, countDependsOn(t.context.rootTemplate.Resources));
+});
+
+test('creates a single nested stack chain if enabled without parallel deployments', t => {
+  t.context.config.stackSequence = true;
+
+  t.context.sequenceStacks();
+
+  t.is(9, countDependsOn(t.context.rootTemplate.Resources));
+  t.true(doesNotBecomeCircular(t.context.rootTemplate.Resources));
+});
+
+test('keeps already existing dependsOn directives', t => {
+  t.context.config.stackSequence = true;
+  t.context.rootTemplate.Resources['9NestedStack'].DependsOn = ['Foo'];
+
+  t.context.sequenceStacks();
+
+  t.is(9, countDependsOn(t.context.rootTemplate.Resources));
+  t.is(2, t.context.rootTemplate.Resources['9NestedStack'].DependsOn.length);
+  t.true(doesNotBecomeCircular(t.context.rootTemplate.Resources));
+});
+
+test('creates multiple nested stack chains if enabled with parallel deployments', t => {
+  t.context.config.stackSequence = true;
+  t.context.config.stackParallelDeployments = 3;
+
+  t.context.sequenceStacks();
+
+  t.is(7, countDependsOn(t.context.rootTemplate.Resources));
+  t.true(doesNotBecomeCircular(t.context.rootTemplate.Resources));
+});

--- a/__tests__/sequence-stacks.js
+++ b/__tests__/sequence-stacks.js
@@ -67,7 +67,7 @@ test.beforeEach(t => {
 });
 
 test('does nothing if parallelDeployments is disabled', t => {
-  t.context.config.stackSequence = false;
+  t.context.config.stackConcurrency = 0;
 
   t.context.sequenceStacks();
 
@@ -75,7 +75,7 @@ test('does nothing if parallelDeployments is disabled', t => {
 });
 
 test('creates a single nested stack chain if enabled without parallel deployments', t => {
-  t.context.config.stackSequence = true;
+  t.context.config.stackConcurrency = 1;
 
   t.context.sequenceStacks();
 
@@ -84,7 +84,7 @@ test('creates a single nested stack chain if enabled without parallel deployment
 });
 
 test('keeps already existing dependsOn directives', t => {
-  t.context.config.stackSequence = true;
+  t.context.config.stackConcurrency = 1;
   t.context.rootTemplate.Resources['9NestedStack'].DependsOn = ['Foo'];
 
   t.context.sequenceStacks();
@@ -95,8 +95,7 @@ test('keeps already existing dependsOn directives', t => {
 });
 
 test('creates multiple nested stack chains if enabled with parallel deployments', t => {
-  t.context.config.stackSequence = true;
-  t.context.config.stackParallelDeployments = 3;
+  t.context.config.stackConcurrency = 3;
 
   t.context.sequenceStacks();
 

--- a/lib/migrate-new-resources.js
+++ b/lib/migrate-new-resources.js
@@ -1,17 +1,19 @@
-'use-strict';
+'use strict';
 
 const _ = require('lodash');
 
 const Custom = require('./migration-strategy/custom');
 const PerType = require('./migration-strategy/per-type');
 const PerFunction = require('./migration-strategy/per-function');
+const PerGroupFunction = require('./migration-strategy/per-group-function');
 
 module.exports = function migrateResources() {
   const custom = new Custom(this);
   const perType = new PerType(this);
   const perFunction = new PerFunction(this);
+  const perGroupFunction = new PerGroupFunction(this);
 
-  const strategies = [custom, perFunction, perType];
+  const strategies = [custom, perFunction, perType, perGroupFunction];
 
   _.each(this.resourcesById, (resource, logicalId) => {
     // Skip if already handled at migrate-existing-resources step

--- a/lib/migration-strategy/base-strategy.js
+++ b/lib/migration-strategy/base-strategy.js
@@ -1,0 +1,78 @@
+'use strict';
+
+module.exports = class BaseStrategy {
+
+  constructor(plugin) {
+    Object.assign(this, { plugin });
+
+    this.lambdaStacks = {};
+    this.resourceConcurrency = null;
+
+    if (
+      plugin.config.resourceConcurrency
+      && typeof plugin.config.resourceConcurrency === 'number'
+      && Number.isInteger(plugin.config.resourceConcurrency)
+      && plugin.config.resourceConcurrency > 0
+    ) {
+      this.resourceConcurrency = plugin.config.resourceConcurrency;
+    }
+  }
+
+  migration(resource, logicalId) {
+    if (this.isStrategyActive()) {
+      const destination = this.getDestination(resource, logicalId);
+
+      if (destination && this.resourceConcurrency) {
+        this.setDependsOn(resource, logicalId, destination.destination);
+      }
+
+      return destination;
+    }
+  }
+
+  // Must be overloaded
+  getDestination() {
+    return null
+  }
+
+  // Must be overloaded
+  isStrategyActive() {
+    return false;
+  }
+
+  setDependsOn(resource, logicalId, nestedStackName) {
+    // Lambda already depends on LogGroups, we don't want to create Circular dependencies
+    if (resource.Type === 'AWS::Logs::LogGroup') {
+      return;
+    }
+    let dependsOnLogicalId;
+
+    if (!this.lambdaStacks[nestedStackName]) {
+      this.lambdaStacks[nestedStackName] = new Array(this.resourceConcurrency)
+        .fill([], 0, this.resourceConcurrency);
+    }
+
+    const leastFilled = this.lambdaStacks[nestedStackName].reduce(
+      (accumulator, item) => accumulator + item.length,
+      0
+    ) % this.resourceConcurrency;
+
+    if (this.lambdaStacks[nestedStackName][leastFilled]) {
+      const lastIndex = this.lambdaStacks[nestedStackName][leastFilled].length - 1;
+
+      dependsOnLogicalId = this.lambdaStacks[nestedStackName][leastFilled][lastIndex];
+    }
+
+    this.lambdaStacks[nestedStackName][leastFilled].push(logicalId);
+
+    if (dependsOnLogicalId) {
+      let dependsOn = [dependsOnLogicalId];
+
+      if (resource.DependsOn) {
+        dependsOn = dependsOn.concat(resource.DependsOn);
+      }
+
+      resource.DependsOn = dependsOn;
+    }
+  }
+};

--- a/lib/migration-strategy/custom.js
+++ b/lib/migration-strategy/custom.js
@@ -2,6 +2,8 @@
 
 const path = require('path');
 
+const BaseStrategy = require('./base-strategy');
+
 function loadCustomizations(serverless, plugin) {
   const customPath = path.resolve(
     serverless.config.servicePath,
@@ -24,10 +26,10 @@ function loadCustomizations(serverless, plugin) {
   }
 }
 
-module.exports = class Custom {
+module.exports = class Custom extends BaseStrategy {
 
   constructor(plugin) {
-    this.plugin = plugin;
+    super(plugin);
     this.stacksMap = {};
 
     const customStackMapping = loadCustomizations(plugin.serverless, plugin);
@@ -42,7 +44,12 @@ module.exports = class Custom {
     }
   }
 
-  migration(resource, logicalId) {
+  // overloaded
+  isStrategyActive() {
+    return true;
+  }
+
+  getDestination(resource, logicalId) {
     // legacy, will be removed
     if (typeof this.plugin.constructor.resolveMigration === 'function') {
       const migration = this.plugin.constructor.resolveMigration.call(this, resource, logicalId, this.plugin.serverless);

--- a/lib/migration-strategy/per-function.js
+++ b/lib/migration-strategy/per-function.js
@@ -12,10 +12,12 @@ module.exports = class PerFunction {
   }
 
   migration(resource, logicalId) {
-    const destination = this.getDestination(resource, logicalId);
+    if (this.plugin.config.perFunction) {
+      const destination = this.getDestination(resource, logicalId);
 
-    if (destination) {
-      return { destination };
+      if (destination) {
+        return {destination};
+      }
     }
   }
 
@@ -32,18 +34,14 @@ module.exports = class PerFunction {
   }
 
   getApiGatewayDestination(logicalId) {
-    if (this.apiGatewayResourceMap) {
-      return this.apiGatewayResourceMap.get(logicalId);
-    }
+    return this.apiGatewayResourceMap.get(logicalId);
   }
 
   getLambdaDestination(logicalId) {
-    if (this.lambdaNames) {
-      // TODO: this could probably use a trie structure
-      return this.lambdaNames.find(normalizedLambdaName => {
-        return logicalId.startsWith(normalizedLambdaName);
-      });
-    }
+    // TODO: this could probably use a trie structure
+    return this.lambdaNames.find(normalizedLambdaName => {
+      return logicalId.startsWith(normalizedLambdaName);
+    });
   }
 
   getAllNormalizedLambdaNames(serverless) {
@@ -69,7 +67,7 @@ module.exports = class PerFunction {
     const resourceLambdasMap = new Map();
 
     // Iterate over all configured HTTP endpoints
-    apiGatewayPlugin.validated.events.map(({ functionName, http }) => {
+    apiGatewayPlugin.validated.events.forEach(({ functionName, http }) => {
       // Normalized function name makes part of resource logical id
       const normalizedLambdaName = this.plugin.provider.naming.getNormalizedFunctionName(functionName);
 
@@ -112,4 +110,4 @@ module.exports = class PerFunction {
     return resourceMap;
   }
 
-}
+};

--- a/lib/migration-strategy/per-function.js
+++ b/lib/migration-strategy/per-function.js
@@ -1,35 +1,15 @@
 'use strict';
 
-module.exports = class PerFunction {
+const BaseStrategy = require('./base-strategy');
+
+module.exports = class PerFunction extends BaseStrategy {
 
   constructor(plugin) {
-    Object.assign(this, { plugin });
+    super(plugin);
 
-    if (plugin.config.perFunction) {
+    if (this.isStrategyActive()) {
       this.apiGatewayResourceMap = this.getApiGatewayResourceMap(plugin.serverless);
       this.lambdaNames = this.getAllNormalizedLambdaNames(plugin.serverless);
-    }
-  }
-
-  migration(resource, logicalId) {
-    if (this.plugin.config.perFunction) {
-      const destination = this.getDestination(resource, logicalId);
-
-      if (destination) {
-        return {destination};
-      }
-    }
-  }
-
-  getDestination(resource, logicalId) {
-    switch (resource.Type) {
-      case 'AWS::ApiGateway::Method':
-      case 'AWS::ApiGateway::Resource':
-        return this.getApiGatewayDestination(logicalId);
-      default:
-        // All other resource types if their name starts with one of the lambda names
-        // are propagated to given lambda stack
-        return this.getLambdaDestination(logicalId);
     }
   }
 
@@ -110,4 +90,31 @@ module.exports = class PerFunction {
     return resourceMap;
   }
 
+  // overloaded
+  getDestination(resource, logicalId) {
+    let normalizedLambdaName;
+
+    if (['AWS::ApiGateway::Method', 'AWS::ApiGateway::Resource'].indexOf(resource.Type) !== -1) {
+      normalizedLambdaName = this.getApiGatewayDestination(logicalId);
+    } else {
+      normalizedLambdaName = this.getLambdaDestination(logicalId);
+    }
+
+    if (normalizedLambdaName) {
+      return {
+        destination: this.getNestedStackName(normalizedLambdaName)
+      };
+    }
+  }
+
+  // overloaded
+  isStrategyActive() {
+    return this.plugin.config.perFunction;
+  }
+
+  // Can be overloaded
+  getNestedStackName(normalizedLambdaName) {
+    return normalizedLambdaName;
+  }
 };
+

--- a/lib/migration-strategy/per-group-function.js
+++ b/lib/migration-strategy/per-group-function.js
@@ -9,7 +9,7 @@ class PerGroupFunction extends PerFunction {
   constructor(plugin) {
     super(plugin);
 
-    if (plugin.config.perGroupFunction) {
+    if (this.isStrategyActive()) {
       if (
         !plugin.config.nestedStackCount
         || typeof plugin.config.nestedStackCount !== 'number'
@@ -19,93 +19,20 @@ class PerGroupFunction extends PerFunction {
         throw Error('nestedStackCount configuration must be an integer greater than 2');
       }
 
-      // Super class will not call them as we don't use the same configuration here
-      this.apiGatewayResourceMap = this.getApiGatewayResourceMap(plugin.serverless);
-      this.lambdaNames = this.getAllNormalizedLambdaNames(plugin.serverless);
-
       this.nestedStackCount = plugin.config.nestedStackCount;
-      this.resourceParallelDeployments = 1;
-      this.lambdaStacks = {};
-
-      if (
-        plugin.config.resourceParallelDeployments
-        && typeof plugin.config.resourceParallelDeployments === 'number'
-        && Number.isInteger(plugin.config.resourceParallelDeployments)
-        && plugin.config.resourceParallelDeployments > 0
-      ) {
-        this.resourceParallelDeployments = plugin.config.resourceParallelDeployments;
-      }
     }
   }
 
-
-  migration(resource, logicalId) {
-    if (this.plugin.config.perGroupFunction) {
-      const destination = this.getDestination(resource, logicalId);
-
-      if (destination) {
-        return {destination};
-      }
-    }
-  }
-
-  getDestination(resource, logicalId) {
-    let normalizedLambdaName;
-
-    if (['AWS::ApiGateway::Method', 'AWS::ApiGateway::Resource'].indexOf(resource.Type) !== -1) {
-      normalizedLambdaName = this.getApiGatewayDestination(logicalId);
-    } else {
-      normalizedLambdaName = this.getLambdaDestination(logicalId);
-    }
-
-    if (normalizedLambdaName) {
-      this.setDependsOn(resource, logicalId, normalizedLambdaName);
-      return this.getNestedStackName(normalizedLambdaName);
-    }
-  }
-
-  setDependsOn(resource, logicalId, normalizedLambdaName) {
-    // Lambda already depends on LogGroups, we don't want to create Circular dependencies
-    if (resource.Type === 'AWS::Logs::LogGroup') {
-      return;
-    }
-
-    const nestedStackName = this.getNestedStackName(normalizedLambdaName);
-    let dependsOnLogicalId;
-
-    if (!this.lambdaStacks[nestedStackName]) {
-      this.lambdaStacks[nestedStackName] = new Array(this.resourceParallelDeployments)
-        .fill([], 0, this.resourceParallelDeployments);
-    }
-
-    const leastFilled = this.lambdaStacks[nestedStackName].reduce(
-      (accumulator, item) => accumulator + item.length,
-      0
-    ) % this.resourceParallelDeployments;
-
-    if (this.lambdaStacks[nestedStackName][leastFilled]) {
-      const lastIndex = this.lambdaStacks[nestedStackName][leastFilled].length - 1;
-
-      dependsOnLogicalId = this.lambdaStacks[nestedStackName][leastFilled][lastIndex];
-    }
-
-    this.lambdaStacks[nestedStackName][leastFilled].push(logicalId);
-
-    if (dependsOnLogicalId) {
-      let dependsOn = [dependsOnLogicalId];
-
-      if (resource.DependsOn) {
-        dependsOn = dependsOn.concat(resource.DependsOn);
-      }
-
-      resource.DependsOn = dependsOn;
-    }
-  }
-
+  // overloaded
   getNestedStackName(normalizedLambdaName) {
     const hash = crypto.createHash('sha1').update(normalizedLambdaName).digest('hex');
 
     return String(Number.parseInt(hash.substring(0,10), 16) % this.nestedStackCount + 1);
+  }
+
+  // overloaded
+  isStrategyActive() {
+    return this.plugin.config.perGroupFunction;
   }
 }
 

--- a/lib/migration-strategy/per-group-function.js
+++ b/lib/migration-strategy/per-group-function.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const PerFunction = require('./per-function');
+
+class PerGroupFunction extends PerFunction {
+
+  constructor(plugin) {
+    super(plugin);
+
+    if (plugin.config.perGroupFunction) {
+      if (
+        !plugin.config.nestedStackCount
+        || typeof plugin.config.nestedStackCount !== 'number'
+        || !Number.isInteger(plugin.config.nestedStackCount)
+        || plugin.config.nestedStackCount < 2
+      ) {
+        throw Error('nestedStackCount configuration must be an integer greater than 2');
+      }
+
+      // Super class will not call them as we don't use the same configuration here
+      this.apiGatewayResourceMap = this.getApiGatewayResourceMap(plugin.serverless);
+      this.lambdaNames = this.getAllNormalizedLambdaNames(plugin.serverless);
+
+      this.nestedStackCount = plugin.config.nestedStackCount;
+      this.resourceParallelDeployments = 1;
+      this.lambdaStacks = {};
+
+      if (
+        plugin.config.resourceParallelDeployments
+        && typeof plugin.config.resourceParallelDeployments === 'number'
+        && Number.isInteger(plugin.config.resourceParallelDeployments)
+        && plugin.config.resourceParallelDeployments > 0
+      ) {
+        this.resourceParallelDeployments = plugin.config.resourceParallelDeployments;
+      }
+    }
+  }
+
+
+  migration(resource, logicalId) {
+    if (this.plugin.config.perGroupFunction) {
+      const destination = this.getDestination(resource, logicalId);
+
+      if (destination) {
+        return {destination};
+      }
+    }
+  }
+
+  getDestination(resource, logicalId) {
+    let normalizedLambdaName;
+
+    if (['AWS::ApiGateway::Method', 'AWS::ApiGateway::Resource'].indexOf(resource.Type) !== -1) {
+      normalizedLambdaName = this.getApiGatewayDestination(logicalId);
+    } else {
+      normalizedLambdaName = this.getLambdaDestination(logicalId);
+    }
+
+    if (normalizedLambdaName) {
+      this.setDependsOn(resource, logicalId, normalizedLambdaName);
+      return this.getNestedStackName(normalizedLambdaName);
+    }
+  }
+
+  setDependsOn(resource, logicalId, normalizedLambdaName) {
+    // Lambda already depends on LogGroups, we don't want to create Circular dependencies
+    if (resource.Type === 'AWS::Logs::LogGroup') {
+      return;
+    }
+
+    const nestedStackName = this.getNestedStackName(normalizedLambdaName);
+    let dependsOnLogicalId;
+
+    if (!this.lambdaStacks[nestedStackName]) {
+      this.lambdaStacks[nestedStackName] = new Array(this.resourceParallelDeployments)
+        .fill([], 0, this.resourceParallelDeployments);
+    }
+
+    const leastFilled = this.lambdaStacks[nestedStackName].reduce(
+      (accumulator, item) => accumulator + item.length,
+      0
+    ) % this.resourceParallelDeployments;
+
+    if (this.lambdaStacks[nestedStackName][leastFilled]) {
+      const lastIndex = this.lambdaStacks[nestedStackName][leastFilled].length - 1;
+
+      dependsOnLogicalId = this.lambdaStacks[nestedStackName][leastFilled][lastIndex];
+    }
+
+    this.lambdaStacks[nestedStackName][leastFilled].push(logicalId);
+
+    if (dependsOnLogicalId) {
+      let dependsOn = [dependsOnLogicalId];
+
+      if (resource.DependsOn) {
+        dependsOn = dependsOn.concat(resource.DependsOn);
+      }
+
+      resource.DependsOn = dependsOn;
+    }
+  }
+
+  getNestedStackName(normalizedLambdaName) {
+    const hash = crypto.createHash('sha1').update(normalizedLambdaName).digest('hex');
+
+    return String(Number.parseInt(hash.substring(0,10), 16) % this.nestedStackCount + 1);
+  }
+}
+
+module.exports = PerGroupFunction;

--- a/lib/migration-strategy/per-type.js
+++ b/lib/migration-strategy/per-type.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const BaseStrategy = require('./base-strategy');
+
 const DEFAULT_STACKS_MAP = {
   'AWS::CloudWatch::Alarm': {
     destination: 'Alarms',
@@ -39,18 +41,26 @@ const DEFAULT_STACKS_MAP = {
   }
 };
 
-module.exports = class PerType {
+module.exports = class PerType extends BaseStrategy {
 
   constructor(plugin) {
+    super(plugin);
+
     this.stacksMap = {};
 
-    if (plugin.config.perType || plugin.config.perType === undefined) {
+    if (this.isStrategyActive()) {
       Object.assign(this.stacksMap, DEFAULT_STACKS_MAP);
     }
   }
 
-  migration(resource) {
+  //overloaded
+  isStrategyActive() {
+    return this.plugin.config.perType || this.plugin.config.perType === undefined;
+  }
+
+  // overloaded
+  getDestination(resource) {
     return this.stacksMap[resource.Type];
   }
-  
-}
+
+};

--- a/lib/sequence-stacks.js
+++ b/lib/sequence-stacks.js
@@ -1,0 +1,37 @@
+'use strict';
+
+module.exports = function sequenceStacks() {
+  if (this.config.stackSequence) {
+    let stackParallelDeployments = 1;
+
+    if (
+      this.config.stackParallelDeployments
+      && typeof this.config.stackParallelDeployments === 'number'
+      && Number.isInteger(this.config.stackParallelDeployments)
+      && this.config.stackParallelDeployments > 0
+    ) {
+      stackParallelDeployments = this.config.stackParallelDeployments;
+    }
+
+    const stackLogicalIds = Object.keys(this.nestedStacks);
+
+    stackLogicalIds.forEach((logicalId, index) => {
+      const resource = this.rootTemplate.Resources[logicalId];
+      let parentLogicalId = null;
+
+      if (index >= stackParallelDeployments) {
+        parentLogicalId = stackLogicalIds[index - stackParallelDeployments];
+      }
+
+      if (parentLogicalId) {
+        let dependsOn = [parentLogicalId];
+
+        if (resource.DependsOn) {
+          dependsOn = dependsOn.concat(resource.DependsOn)
+        }
+
+        resource.DependsOn = dependsOn;
+      }
+    })
+  }
+};

--- a/lib/sequence-stacks.js
+++ b/lib/sequence-stacks.js
@@ -1,17 +1,13 @@
 'use strict';
 
 module.exports = function sequenceStacks() {
-  if (this.config.stackSequence) {
-    let stackParallelDeployments = 1;
-
-    if (
-      this.config.stackParallelDeployments
-      && typeof this.config.stackParallelDeployments === 'number'
-      && Number.isInteger(this.config.stackParallelDeployments)
-      && this.config.stackParallelDeployments > 0
-    ) {
-      stackParallelDeployments = this.config.stackParallelDeployments;
-    }
+  if (
+    this.config.stackConcurrency
+    && typeof this.config.stackConcurrency === 'number'
+    && Number.isInteger(this.config.stackConcurrency)
+    && this.config.stackConcurrency > 0
+  ) {
+    const stackConcurrency = this.config.stackConcurrency;
 
     const stackLogicalIds = Object.keys(this.nestedStacks);
 
@@ -19,8 +15,8 @@ module.exports = function sequenceStacks() {
       const resource = this.rootTemplate.Resources[logicalId];
       let parentLogicalId = null;
 
-      if (index >= stackParallelDeployments) {
-        parentLogicalId = stackLogicalIds[index - stackParallelDeployments];
+      if (index >= stackConcurrency) {
+        parentLogicalId = stackLogicalIds[index - stackConcurrency];
       }
 
       if (parentLogicalId) {

--- a/split-stacks.js
+++ b/split-stacks.js
@@ -9,6 +9,7 @@ const replaceReferences = require('./lib/replace-references');
 const replaceConditions = require('./lib/replace-conditions');
 const replaceOutputs = require('./lib/replace-outputs');
 const mergeStackResources = require('./lib/merge-stack-resources');
+const sequenceStacks = require('./lib/sequence-stacks');
 const writeNestedStacks = require('./lib/write-nested-stacks');
 const logSummary = require('./lib/log-summary');
 
@@ -37,6 +38,7 @@ class ServerlessPluginSplitStacks {
       { replaceConditions },
       { replaceOutputs },
       { mergeStackResources },
+      { sequenceStacks },
       { writeNestedStacks },
       { logSummary }
     );
@@ -60,6 +62,7 @@ class ServerlessPluginSplitStacks {
       .then(() => this.replaceOutputs())
       .then(() => this.replaceConditions())
       .then(() => this.mergeStackResources())
+      .then(() => this.sequenceStacks())
       .then(() => this.writeNestedStacks())
       .then(() => this.logSummary());
   }


### PR DESCRIPTION
This Pull Request adds 2 main features:

### A new migration strategy: `perGroupFunction`

It allows to control the number of nested stacks following a `perFunction` strategy. Resources attached to the Lambda are always in the same nested stack, except if they are shared with some other lambda like the `perFunction` strategy. A nested stack can contain one or more Lambdas and its resources depending on configurations below.
Resources within a nested stack are declared to define a `DependsOn` chain to control their deployment. It is possible to create more than one chain to deploy resources in parallel.

Following configurations are introduced:
- `perGroupFunction` (a boolean): enables the migration strategy; `perFunction` and `perType` take precedence if enabled.
- `nestedStackCount` (an integer greater than 2): number of desired Nested Stacks produced by the migration strategy. As it depends on a determinist repartition, you might not get exactly the desired count, if your lambda and nested stack counts are close from each other. Only applies if `perGroupFunction` is enabled.
- `resourceParallelDeployments` (an integer greater than 1): controls the number of resources deployed in parallel. If not set, all resources in the nested stack are deployed sequentially. Only applies if `perGroupFunction` is enabled.


### A new configuration: `stackSequence`

It allows to control if the nested stacks must be deployed sequentially. If enabled the nested stacks are deployed one at a time. You can use an optional configuration to control the number of stacks deployed in parallel.

Following configurations are introduced:
- `stackSequence` (a boolean): enables the deployment control process; defaults value is false.
- `stackParallelDeployments` (an integer greater than 1): number of desired Nested Stacks to deploy in parallel. If not set, all the nested stack are deployed sequentially. Only applies if `stackSequence` is enabled.


### Objectives

- Provide more control over your stack deployment (Notably to avoid `API rate limit` errors).
- Reduce the number of generated nested stacks introduced by the `perFunction` (Notably to avoid the maximum count of CloudFormation stacks soft limit).
- Avoid circular dependencies that can occur when the plugin is used in interaction with other plugins (Notably serverless-dependson-plugin).