### PR TITLE
Add support for Fn::Sub to work with pseudo parameters plugin

### DIFF
--- a/__tests__/utils/get-referenced-resources.js
+++ b/__tests__/utils/get-referenced-resources.js
@@ -136,6 +136,38 @@ test('should find Join references', t => {
   t.deepEqual(_.difference(references.map(r => r.id), ['abc', 'def']).length, 0);
 });
 
+test('should find Sub references', t => {
+  t.context.resourcesById = {
+    'domain': {},
+    'vpc': {},
+    'table': {},
+    'nope': {},
+  };
+
+  const references = t.context.getReferencedResources({
+    Foo: {
+      Mapping: {
+        'Fn::Sub': ['www.${Domain}', {Domain: {Ref: "domain"}}],
+      },
+      noMapping: {
+        Ref: {
+          'Fn::Sub': 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/${vpc}',
+        },
+        Att: {
+          'Fn::Sub': '${table.Arn}',
+        },
+      },
+      Literal: {
+        'Fn::Sub': '${!nope}',
+      },
+      none: 'zzz',
+    },
+  });
+
+  t.deepEqual(references.length, 3);
+  t.deepEqual(_.difference(references.map(r => r.id), ['domain', 'vpc', 'table']).length, 0);
+});
+
 test('should find Fn::Equals references', t => {
   t.context.resourcesById = {
     'abc': {},

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,31 @@ function toArray(thing) {
   }
 }
 
+function varStringToMappings(varString) {
+  const re = /\${(!?[a-zA-Z0-9.]+)}/g;
+  let match;
+  let s = varString;
+  let mappings = {};
+
+  while ((match = re.exec(varString)) !== null) {
+    const [fullMatch, group] = match;
+    if (group.startsWith('!')) {
+      // escape character
+      s = s.replace(fullMatch, `\${${group.substring(1)}}`);
+    } else if (group.includes('.')) {
+      // GetAtt
+      const varName = group.replace('.', '_');
+      mappings[varName] = {'Fn::GetAtt': group.split('.')};
+      s = s.replace(fullMatch, `\${${varName}}`);
+    } else {
+      // Ref
+      mappings[group] = {'Ref': group};
+    }
+  }
+
+  return {varString: s, mappings};
+}
+
 module.exports = {
 
   log(msg) {
@@ -203,6 +228,7 @@ module.exports = {
         const Ref = currentValue.Ref;
         const GetAtt = currentValue['Fn::GetAtt'];
         const Join = currentValue['Fn::Join'];
+        const Sub = currentValue['Fn::Sub'];
 
         if (Ref && Ref in this.resourcesById) {
           references.push(new Reference(Ref, current));
@@ -217,6 +243,26 @@ module.exports = {
             value: Join[1],
             parent: Join,
             key: 1
+          });
+        } else if (Sub) {
+          // dictionary of form {[VarName: string]: VarValue}
+          let mappings;
+
+          if (typeof Sub === 'string') {
+            // Fn::Sub without a Mapping, convert to version with mapping
+            // (Reference requires a parent with a replaceable key which is not possible for the string version)
+            let varString = Sub;
+            ({varString, mappings} = varStringToMappings(varString));
+            currentValue['Fn::Sub'] = [varString, mappings];
+          } else {
+            // Fn::Sub with a Mapping, Sub has format [StringWithVars, MappingDict]
+            mappings = Sub[1];
+          }
+
+          todo.push({
+            value: mappings,
+            parent: currentValue['Fn::Sub'],
+            key: 1,
           });
         } else {
           _.each(currentValue, (nextValue, nextKey) => {


### PR DESCRIPTION
Fixes https://github.com/dougmoscrop/serverless-plugin-split-stacks/issues/94
Convert string version of Fn::Sub to mapping with Ref and Fn: GetAtt and use existing functionality to create references
@see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html