### PR TITLE
fix: remove peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
     "lodash": "^4.17.15",
     "semver": "^6.3.0",
     "throat": "^5.0.0"
-  },
-  "peerDependencies": {
-    "serverless": "1"
   }
 }


### PR DESCRIPTION
Serverless framework is installed as a global package. Peer dependencies do not work with global packages.