### PR TITLE
Set stack outputs on migrate

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -147,6 +147,7 @@ module.exports = {
     const stackResource = this.nestedStackResource(stackName);
 
     stack.Resources[logicalId] = resource;
+    stack.Outputs[logicalId] = null;
 
     this.resourceMigrations[logicalId] = new Migration({
       logicalId,


### PR DESCRIPTION
Because `Object.keys(outputs).length < 60` on
`lib/util.js#stackHasRoom` always returns true.