### PR TITLE
fix: update CloudFormation stack limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # serverless-plugin-split-stacks
 
-This plugin migrates CloudFormation resources in to nested stacks in order to work around the 200 resource limit.
+This plugin migrates CloudFormation resources in to nested stacks in order to work around the 500 resource limit.
 
 There are built-in migration strategies that can be turned on or off as well as defining your own custom migrations. It is a good idea to select the best strategy for your needs from the start because the only reliable method of changing strategy later on is to recreate the deployment from scratch. You configure this in your `serverless.yml` (defaults shown):
 
@@ -60,7 +60,7 @@ custom:
 
 ## Limitations
 
-This plugin is not a substitute for fine-grained services - try to limit the size of your service. This plugin has a hard limit of 200 sub-stacks and does not try to create any kind of tree of nested stacks.
+This plugin is not a substitute for fine-grained services - try to limit the size of your service. This plugin has a hard limit of 500 sub-stacks and does not try to create any kind of tree of nested stacks.
 
 ## Advanced Usage
 

--- a/__tests__/utils/get-stack-name.js
+++ b/__tests__/utils/get-stack-name.js
@@ -5,8 +5,8 @@ const sinon = require('sinon');
 
 const utils = require('../../lib/utils');
 
-const fullResources = Array(200).fill().map(() => {});
-const fullOutputs = Array(60).fill().map(() => {});
+const fullResources = Array(500).fill().map(() => {});
+const fullOutputs = Array(200).fill().map(() => {});
 
 test.beforeEach(t => {
 	t.context = Object.assign({}, utils);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -192,8 +192,8 @@ module.exports = {
     const resources = stack.Resources || {};
     const outputs = stack.Outputs || {};
 
-    return Object.keys(resources).length < 200
-      && Object.keys(outputs).length < 60;
+    return Object.keys(resources).length < 500
+      && Object.keys(outputs).length < 200;
   },
 
   getReferencedResources(start) {


### PR DESCRIPTION
Update the limits to adhere to the newly announced limits https://aws.amazon.com/about-aws/whats-new/2020/10/aws-cloudformation-now-supports-increased-limits-on-five-service-quotas/