### PR TITLE
newer versions compliant error message

### DIFF
--- a/lib/migrate-existing-resources.js
+++ b/lib/migrate-existing-resources.js
@@ -7,7 +7,7 @@ module.exports = function getCurrentState() {
 
   return this.getStackSummary(rootStackName)
     .catch(e => {
-      if (e.message === `Stack with id ${rootStackName} does not exist`) {
+      if (e.message && e.message.indexOf(`Stack with id ${rootStackName} does not exist`) > -1) {
         return [];
       }
       throw e;


### PR DESCRIPTION
Fixes #163 

Using `indexOf` instead of `===` will make it work with any serverless version.