### PR TITLE
Communicate support for `serverless` v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "throat": "^6.0.1"
   },
   "peerDependencies": {
-    "serverless": "1"
+    "serverless": "1 || 2"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
I believe this plugin works without issues with v2 version of the Framework.

Listing `1` unnecessary restricts users to v1 (which will be installed by latest package managers)

Fixes https://github.com/dougmoscrop/serverless-plugin-split-stacks/issues/165