### PR TITLE
Mark plugin as Serverless Framework v3 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "throat": "^6.0.1"
   },
   "peerDependencies": {
-    "serverless": "1 || 2"
+    "serverless": "1 || 2 || 3"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
Plugin is confirmed to work with v3 release without issues, therefore it'll be good to whitelist v3 of the Framework in peer dependencies section