### PR TITLE
feat: support `--minify-template` flag

### DIFF
--- a/__tests__/write-nested-stacks.js
+++ b/__tests__/write-nested-stacks.js
@@ -13,7 +13,8 @@ test.beforeEach(t => {
 			},
       utils: {
 				writeFileSync: sinon.stub()
-			}
+			},
+			options: {}
     }
   });
 });
@@ -36,4 +37,19 @@ test('does nothing when there are no nested stacks', t => {
 	t.context.writeNestedStacks();
 
 	t.false(t.context.serverless.utils.writeFileSync.called);
+});
+
+test('calls write with minified JSON when --minify-template is set', t => {
+	t.context.getFileName = () => 'foo.json';
+	t.context.nestedStacks = {
+		Foo: { bar: {} },
+	};
+	t.context.serverless.options['minify-template'] = true;
+
+	t.context.writeNestedStacks();
+
+	t.true(t.context.serverless.utils.writeFileSync.calledOnce);
+	t.true(
+		t.context.serverless.utils.writeFileSync.getCall(0).args[1] === '{"bar":{}}'
+	);
 });

--- a/__tests__/write-nested-stacks.js
+++ b/__tests__/write-nested-stacks.js
@@ -13,9 +13,9 @@ test.beforeEach(t => {
 			},
       utils: {
 				writeFileSync: sinon.stub()
-			},
-			options: {}
-    }
+			}
+    },
+		options: {}
   });
 });
 
@@ -44,7 +44,7 @@ test('calls write with minified JSON when --minify-template is set', t => {
 	t.context.nestedStacks = {
 		Foo: { bar: {} },
 	};
-	t.context.serverless.options['minify-template'] = true;
+	t.context.options['minify-template'] = true;
 
 	t.context.writeNestedStacks();
 

--- a/lib/write-nested-stacks.js
+++ b/lib/write-nested-stacks.js
@@ -18,8 +18,6 @@ module.exports = function writeNestedStacks() {
       stack = JSON.stringify(stack, null, 0);
      }
 
-     console.log('call', destination, stack)
-
      this.serverless.utils.writeFileSync(destination, stack);
    });
  }

--- a/lib/write-nested-stacks.js
+++ b/lib/write-nested-stacks.js
@@ -14,6 +14,12 @@ module.exports = function writeNestedStacks() {
        fileName
      );
 
+     if(this.serverless.options['minify-template']) {
+      stack = JSON.stringify(stack, null, 0);
+     }
+
+     console.log('call', destination, stack)
+
      this.serverless.utils.writeFileSync(destination, stack);
    });
  }

--- a/lib/write-nested-stacks.js
+++ b/lib/write-nested-stacks.js
@@ -14,7 +14,7 @@ module.exports = function writeNestedStacks() {
        fileName
      );
 
-     if(this.serverless.options['minify-template']) {
+     if(this.options['minify-template']) {
       stack = JSON.stringify(stack, null, 0);
      }
 


### PR DESCRIPTION
Closes https://github.com/dougmoscrop/serverless-plugin-split-stacks/issues/209 by converting template objects into minified JSON before they are passed to the Serverless writeFileSync util. When given a Javascript object, their util will convert it to pretty JSON before writing it to file.