### PR TITLE
Added ServerlessDeploymentBucket handling for Serverless V4

### DIFF
--- a/__tests__/utils/bucket-name.js
+++ b/__tests__/utils/bucket-name.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const test = require('ava');
+const sinon = require('sinon');
+
+const setDeploymentBucketName = require('../../lib/deployment-bucket-name');
+
+function createOriginalContext() {
+  return {
+    serverless: {
+      service: {
+        provider: {}
+      },
+      getProvider: sinon.stub().callsFake((providerName) => {
+        if (providerName === 'aws') {
+          return {
+            getServerlessDeploymentBucketName: sinon.stub().resolves('mock-bucket-name')
+          };
+        }
+      }),
+      version: '4.0.0'
+    },
+    options: {}
+  };
+}
+
+test.beforeEach(t => {
+  t.context = createOriginalContext();
+});
+
+test('sets deployment bucket name if explicitly defined', async t => {
+  t.context.serverless.service.provider.deploymentBucket = 'explicit-bucket';
+
+  await setDeploymentBucketName.call(t.context);
+
+  t.is(t.context.deploymentBucketName, 'explicit-bucket');
+});
+
+test('fetches deployment bucket name for Serverless v4 and sets it', async t => {
+  t.context.serverless.version = '4.0.0';
+  t.context.serverless.service.provider.deploymentBucket = undefined;
+
+  await setDeploymentBucketName.call(t.context);
+
+  t.is(t.context.deploymentBucketName, 'mock-bucket-name');
+});
+
+test('sets deployment bucket using Ref syntax for Serverless versions below v4', async t => {
+  t.context.serverless.version = '3.8.0';
+  t.context.serverless.service.provider.deploymentBucket = undefined;
+
+  await setDeploymentBucketName.call(t.context);
+
+  t.deepEqual(t.context.deploymentBucketName, { Ref: 'ServerlessDeploymentBucket' });
+});
+
+test('throws an error if getServerlessDeploymentBucketName fails', async t => {
+  t.context.serverless.getProvider = sinon.fake.returns({
+    getServerlessDeploymentBucketName: sinon.fake.rejects(new Error('Failed to retrieve bucket'))
+  });
+  t.context.serverless.version = '4.0.0';
+
+  const error = await t.throwsAsync(() => setDeploymentBucketName.call(t.context));
+
+  t.is(error.message, 'Failed to set deployment bucket name: Failed to retrieve bucket');
+});

--- a/__tests__/utils/nested-stack-resource.js
+++ b/__tests__/utils/nested-stack-resource.js
@@ -7,6 +7,7 @@ const utils = require('../../lib/utils');
 
 test.beforeEach(t => {
 	t.context = Object.assign({}, utils, {
+		deploymentBucketName: 'my-bucket-name',
 		deploymentBucketEndpoint: 's3.amazonaws.com',
 		serverless: {
 			service: {
@@ -27,7 +28,8 @@ test('creates a resource with the right type', t => {
 });
 
 test('creates a resource with the right URL', t => {
-	const output = t.context.nestedStackResource('test');
+  t.context.deploymentBucketName = { Ref: 'ServerlessDeploymentBucket' };
+  const output = t.context.nestedStackResource('test');
 
 	t.true(Array.isArray(output.Properties.TemplateURL['Fn::Join']));
 	t.deepEqual(output.Properties.TemplateURL['Fn::Join'][0], '/');
@@ -44,8 +46,6 @@ test('creates a resource with the right URL', t => {
 });
 
 test('creates a resource with the right URL when a custom bucket is used', t => {
-	t.context.serverless.service.provider.deploymentBucket = 'my-bucket-name';
-
 	const output = t.context.nestedStackResource('test');
 
 	t.true(Array.isArray(output.Properties.TemplateURL['Fn::Join']));

--- a/lib/deployment-bucket-name.js
+++ b/lib/deployment-bucket-name.js
@@ -1,0 +1,22 @@
+'use-strict';
+
+module.exports = async function setDeploymentBucketName() {
+  try {
+    const {service: {provider}, version} = this.serverless;
+    const {deploymentBucket} = provider;
+
+    if (deploymentBucket) {
+      this.deploymentBucketName = deploymentBucket;
+      return;
+    }
+
+    const isVersion4OrAbove = parseInt(version.split('.')[0], 10) >= 4;
+    if (isVersion4OrAbove) {
+      this.deploymentBucketName = await this.serverless.getProvider('aws').getServerlessDeploymentBucketName();
+    } else {
+      this.deploymentBucketName = { Ref: 'ServerlessDeploymentBucket' };
+    }
+  } catch (error) {
+    throw new Error(`Failed to set deployment bucket name: ${error.message}`);
+  }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,7 +113,7 @@ module.exports = {
            'Fn::Join': [
              '/', [
                `https://${this.deploymentBucketEndpoint}`,
-               this.serverless.service.provider.deploymentBucket || { Ref: 'ServerlessDeploymentBucket' },
+               this.deploymentBucketName,
                this.serverless.service.package.artifactDirectoryName,
                fileName
              ]

--- a/split-stacks.js
+++ b/split-stacks.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const semver = require('semver');
 
 const setDeploymentBucketEndpoint = require('./lib/deployment-bucket-endpoint');
+const setDeploymentBucketName = require('./lib/deployment-bucket-name');
 const migrateExistingResources = require('./lib/migrate-existing-resources');
 const migrateNewResources = require('./lib/migrate-new-resources');
 const replaceReferences = require('./lib/replace-references');
@@ -34,6 +35,7 @@ class ServerlessPluginSplitStacks {
     Object.assign(this,
       utils,
       { setDeploymentBucketEndpoint },
+      { setDeploymentBucketName },
       { migrateExistingResources },
       { migrateNewResources },
       { replaceReferences },
@@ -59,6 +61,7 @@ class ServerlessPluginSplitStacks {
 
     return Promise.resolve()
       .then(() => this.setDeploymentBucketEndpoint())
+      .then(() => this.setDeploymentBucketName())
       .then(() => this.migrateExistingResources())
       .then(() => this.migrateNewResources())
       .then(() => this.replaceReferences())


### PR DESCRIPTION
I've added logic to allow deployments in serverless V4 with an existing bucket. It doesn't create a new bucket per each service when you have multiple services. It'll use a bucket per project and reuse it with different services.

I've tested it on the latest version of Serverless and it's working fine. However, I *did not* test it with a Serverless v2 or v3 project, although it *should* work.

Also, I've modified the tests to accommodate this behavior.